### PR TITLE
Add README & LICENSE template files into a Kentico repository template

### DIFF
--- a/.github/.CODEOWNERS
+++ b/.github/.CODEOWNERS
@@ -1,0 +1,4 @@
+# Users referenced in this file will automatically be requested as reviewers for PRs that modify the given paths.
+# See https://help.github.com/articles/about-code-owners/
+
+* [Maintainer team https://github.com/Kentico/Home/wiki/Guidelines-for-GitHub-permissions-in-the-Kentico-organization]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,4 +12,3 @@ jobs: # Specifies the section where we describe our jobs.
     steps: # Specifies the section where we describe the job's steps.
     - name: Output some string
       run: echo "Set some actual CI steps"
-head.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+# For more information do to https://github.com/Kentico/Home/wiki/CI-and-Automation-Guidelines
+
+name: "Build"   # Represents the name of the whole action.
+on:   # Specifies the section where we describe our build triggers.
+  push: # The action runs with push.
+  pull_request: # The action runs with a pull request.
+  schedule: # Specifies the section where we describe the schedule of running the action.
+    - cron: '0 18 * * 1' # The CRON expression describes when to run the action.
+jobs: # Specifies the section where we describe our jobs.
+  Build: # Specific job section.
+    runs-on: ubuntu-latest   # Describes the environment.
+    steps: # Specifies the section where we describe the job's steps.
+    - name: Output some string
+      run: echo "Set some actual CI steps"
+head.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) [Current year here] Kentico
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,81 @@
+[![Contributors][contributors-shield]][contributors-url]
+[![Forks][forks-shield]][forks-url]
+[![Stargazers][stars-shield]][stars-url]
+[![Issues][issues-shield]][issues-url]
+[![MIT License][license-shield]][license-url]
+[![Discord][discussion-shield]][discussion-url]
+
+
+
+<!-- ABOUT THE PROJECT -->
+## About The Project
+
+Please put here some general information about your Intergration / App / Solution.
+
+
+
+<!-- GETTING STARTED -->
+## Getting Started
+
+This is an example of how you may give instructions on setting up your project locally.
+To get a local copy up and running follow these simple example steps.
+
+### Prerequisites
+
+This is an example of how to list things you need to use the software and how to install them.
+* npm
+  ```sh
+  npm install npm@latest -g
+  ```
+
+### Installation
+
+_Below is an example of how you can instruct your audience on installing and setting up your app. This template doesn't rely on any external dependencies or services._
+
+1. Get a free API Key at ... 
+2. Clone the repo
+   ```sh
+   git clone ...
+   ```
+3. Install
+4. Enter your API ...
+
+
+
+<!-- USAGE EXAMPLES -->
+## Usage
+
+Use this space to show useful examples of how a project can be used. Additional screenshots, code examples and demos work well in this space. You may also link to more resources.
+
+_For more examples, please refer to the [Documentation](put URL to documentation here)_
+
+
+
+<!-- CONTRIBUTING -->
+## Contributing
+
+For Contributing please see  <a href="./CONTRIBUTING.md">`CONTRIBUTING.md`</a> for more information.
+
+
+
+<!-- LICENSE -->
+## License
+
+Distributed under the MIT License. See [`LICENSE.md`](./LICENSE.md) for more information.
+
+
+
+<!-- MARKDOWN LINKS & IMAGES -->
+<!-- https://github.com/Kentico/Home/wiki/Checklist-for-publishing-a-new-OS-project#badges-->
+[contributors-shield]: https://img.shields.io/github/contributors/Kentico/kontent-custom-element-samples.svg?style=for-the-badge
+[contributors-url]: https://github.com/Kentico/repo-template/graphs/contributors
+[forks-shield]: https://img.shields.io/github/forks/Kentico/kontent-custom-element-samples.svg?style=for-the-badge
+[forks-url]: https://github.com/Kentico/repo-template/network/members
+[stars-shield]: https://img.shields.io/github/stars/Kentico/kontent-custom-element-samples.svg?style=for-the-badge
+[stars-url]: https://github.com/Kentico/repo-template/stargazers
+[issues-shield]: https://img.shields.io/github/issues/Kentico/kontent-custom-element-samples.svg?style=for-the-badge
+[issues-url]:https://github.com/Kentico/repo-template/issues
+[license-shield]: https://img.shields.io/github/license/Kentico/kontent-custom-element-samples.svg?style=for-the-badge
+[license-url]:https://github.com/Kentico/repo-template/blob/master/LICENSE.md
+[discussion-shield]: https://img.shields.io/discord/821885171984891914?color=%237289DA&label=Kontent%20Discord&logo=discord
+[discussion-url]: https://discord.com/invite/SKCxwPtevJ


### PR DESCRIPTION
### Motivation

The template for new Kentico repositories has been a little bit shallow.
There was no README.md and LICENSE.md file with a basic template for the user's information.
I took the liberty to put them into our template.

### Checklist

- [X] Code follows coding conventions held in this repo
- [X] Automated tests have been added - no tests needed
- [X] Tests are passing - no tests needed
- [X] Docs have been updated (if applicable)
- [X] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

- Check if the README.md file exists, the file is not empty and has valid information.
- Check if the LICENSE.md file exists, the file is not empty and has valid information.
