### PR TITLE
Integrate dotnet format check into GH pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Run dotnet format
-        run: dotnet format src/Kentico.Xperience.RepoTemplate/Kentico.Xperience.RepoTemplate.csproj --verify-no-changes
+        run: dotnet format Kentico.Xperience.RepoTemplate.sln --exclude ./examples/** --verify-no-changes
 
   build_and_test:
     name: Build and Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,20 @@ on:
       - "**.sln"
 
 jobs:
+  dotnet-format:
+    name: .Net Format Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Run dotnet format
+        run: dotnet format src/Kentico.Xperience.RepoTemplate/Kentico.Xperience.RepoTemplate.csproj --verify-no-changes
+
   build_and_test:
     name: Build and Test
     runs-on: ubuntu-latest
+    needs: dotnet-format
     defaults:
       run:
         shell: pwsh

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,12 +20,14 @@
     {
       "type": "shell",
       "command": "dotnet",
-      "args": ["format"],
+      "args": [
+        "format",
+        "Kentico.Xperience.RepoTemplate.sln",
+        "--exclude",
+        "./examples/**"
+      ],
       "problemMatcher": ["$msCompile"],
       "group": "none",
-      "options": {
-        "cwd": "${workspaceFolder}/src/Kentico.Xperience.RepoTemplate/"
-      },
       "label": "dotnet: format"
     },
     {

--- a/docs/Contributing-Setup.md
+++ b/docs/Contributing-Setup.md
@@ -68,7 +68,7 @@ To run the Sample app Admin customization in development mode, add the following
    - `refactor/` - for restructuring of existing features
    - `fix/` - for bugfixes
 
-1. Run `dotnet format` against the `src/Kentico.Xperience.RepoTemplate` project
+1. Run `dotnet format` against the `Kentico.Xperience.RepoTemplate` solution
 
    > use `dotnet: format` VS Code task.
 


### PR DESCRIPTION
# Motivation

Although we already require execution of dotnet format as one of the steps to successful [contribution](https://github.com/Kentico/repo-template/blob/b74efb334366e3aabab603dde015397fd782c207/docs/Contributing-Setup.md?plain=1#L71) we do not verify that contributors have actually executed the formatting command before submitting to the repository. As a result, effective automation became impossible, as those using the dotnet format would see changes to files that were not touched by themselves during implementation.

Therefore, this PR adds dotnet format check directly to the pipeline.

## Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

If manual testing is required, what are the steps?
