### PR TITLE
Update version of native GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run dotnet format
         run: dotnet format Kentico.Xperience.RepoTemplate.sln --exclude ./examples/** --verify-no-changes
@@ -40,10 +40,10 @@ jobs:
       DOTNET_NOLOGO: 1
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
           global-json-file: global.json
 


### PR DESCRIPTION
# Motivation

Updating version of GH actions in order to fix deprecated Node.js warning

![image](https://github.com/Kentico/repo-template/assets/64188398/8a2c3180-070b-4cf6-91bc-457dd407f4d6)


## Checklist

- [x] Code follows coding conventions held in this repo
- [x] Automated tests have been added
- [x] Tests are passing
- [x] Docs have been updated (if applicable)
- [x] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

## How to test

Verify GH pipeline works as expected.
