### PR TITLE
Run CI build in PRs and after merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,16 +3,8 @@ name: "CI: Build and Test"
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "**.cs"
-      - "**.cshtml"
-      - "**.tsx"
-      - "**.js"
-      - "**.json"
-      - "**.csproj"
-      - "**.props"
-      - "**.targets"
-      - "**.sln"
+  push:
+    branches: [main]
 
 jobs:
   dotnet-format:


### PR DESCRIPTION
# Motivation

The main branch protection rule requires these checks to pass, but current filters may prevent the build from running. We also recently agreed to run the build after the PR is merged (or after any push to the main branch).

We discussed this in person. The result is tracked in this [comment](https://kentico.atlassian.net/wiki/spaces/XDEVOPS/pages/4751949920/Set+up+a+new+GitHub+repository?focusedCommentId=4752343065).