### PR TITLE
Remove unmaintained extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,9 +3,7 @@
     "ms-dotnettools.csdevkit",
     "editorconfig.editorconfig",
     "davidanson.vscode-markdownlint",
-    "tintoy.msbuild-project-tools",
     "esbenp.prettier-vscode",
-    "dotjoshjohnson.xml",
     "ms-azure-devops.azure-pipelines"
   ]
 }


### PR DESCRIPTION
### Motivation

- Remove unmaintained VS Code extension recommendations as supply-chain security precaution

### Checklist

- [X] Code follows coding conventions held in this repo
- [ ] Automated tests have been added
- [X] Tests are passing
- [ ] Docs have been updated (if applicable)
- [ ] Temporary settings (e.g. variables used during development and testing) have been reverted to defaults

### How to test

n/a
